### PR TITLE
cleans up unnecessary methods for live mode, bug fix for pending time when running live

### DIFF
--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -35,17 +35,6 @@ class TestRun < ApplicationRecord
     timeline
   end
 
-  def live_timeline
-    grouped_steps = program.steps.includes(:step_statuses).group_by { |ss| ss.sequence_number}
-    timeline = []
-    grouped_steps.each do |key, value|
-      @time ||= 0
-      timeline << fill_live_values(value, key, @time)
-      @time = value.first.duration + @time
-    end
-    timeline
-  end
-
    def fill_values(step_status, sequence_number, start_time)
     [
       step_status.first.test_run_id.to_s,
@@ -57,26 +46,6 @@ class TestRun < ApplicationRecord
     ]
   end
 
-  def fill_live_values(steps_array, sequence_number, time)
-    [
-      steps_array.first.program_id.to_s,
-      "#{sequence_number}: #{steps_array.first.description}",
-      time*1000,
-      (time+steps.first.duration)*1000,
-      steps_array.first.id.to_s,
-      build_live_step_info(steps_array)
-    ]
-  end
-
-  def build_live_step_info(steps_array)
-    step_info = {}
-    step_info[:duration] = steps_array.first.duration
-    step_info[:description] = steps_array.first.description
-    step_info[:status] = steps_array.last.step_statuses.last.status
-    calc_live_times(steps_array, step_info)
-    step_info
-  end
-
   def build_step_info(step_status)
     step_info = {}
     calc_times(step_status, step_info)
@@ -86,16 +55,10 @@ class TestRun < ApplicationRecord
     step_info
   end
 
-  def calc_live_times(steps_array, step_info)
-    step_info[:pending_time] = "n/a"
-    step_info[:soaking_time] = "n/a"
-    step_info[:run_time] = step_info[:duration]
-  end
-
   def calc_times(steps_array, step_info)
     temp = {}
     steps_array.each_with_object(temp) {|s, memo| memo[s.status] = s.started_at }
-    temp["pending"] ? step_info[:pending_time] = (temp["soaking"] - temp["pending"]) : step_info[:pending_time] = 0
+    temp["pending"] && temp["soaking"] ? step_info[:pending_time] = (temp["soaking"] - temp["pending"]) : step_info[:pending_time] = 0
     temp["completed"] ? step_info[:soaking_time] = temp["completed"] - temp["soaking"] : step_info[:soaking_time] = 0
     temp["pending"] ? step_info[:run_time] = step_info[:pending_time] + step_info[:soaking_time] : step_info[:run_time] = step_info[:soaking_time]
   end

--- a/client/src/Timeline.jsx
+++ b/client/src/Timeline.jsx
@@ -47,7 +47,6 @@ class Timeline extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.removeTooltip
     if (this.props.testRunId !== nextProps.testRunId || this.props.tickCounter !== nextProps.tickCounter) {
       nextProps.testRunId && this.getInfo(`timeline/${nextProps.testRunId}`);
     };

--- a/spec/controllers/test_run_spec.rb
+++ b/spec/controllers/test_run_spec.rb
@@ -23,8 +23,10 @@ describe TestRunController do
     expect(JSON.parse(response.body).keys.sort).to eq(PROGRAM_INFO_KEYS.sort)
   end
 
-  xit "knows its step status info" do
-    get :timeline, :format => :JSON, :params => {:id => 1}
-    expect(JSON.parse(response.body).first[:step_info].keys.sort).to eq(STEP_INFO_KEYS.sort)
+  describe "#timeline" do
+    it "delivers a hash with step status information" do
+      get :timeline, :format => :JSON, :params => {:id => 1}
+      expect(JSON.parse(response.body).first[5].keys.sort).to eq(STEP_INFO_KEYS.sort)
+    end
   end
 end

--- a/spec/models/test_run_spec.rb
+++ b/spec/models/test_run_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe TestRun, type: :model do
 
   let(:test_run1) { TestRun.find 1 }
   let(:elapsed_time) { 30 }
-  let(:test_run1_timeline) { [["1", "11: step description", 0, 30000, "1",
+  let(:test_run1_timeline) { [["1", "25: step description", 0, 30000, "1",
                               {:pending_time=>30, :soaking_time=>0, :run_time=>30,
                                :duration=>1, :description=>"step description",
                                :status=>"completed"}],
-                              ["1", "12: step description", 0, 30000, "2",
+                              ["1", "26: step description", 0, 30000, "2",
                               {:pending_time=>30, :soaking_time=>0, :run_time=>30,
                                :duration=>1, :description=>"step description",
                                :status=>"completed"}]] }
@@ -38,7 +38,10 @@ RSpec.describe TestRun, type: :model do
 
   describe "#timeline" do
     context "for a completed program" do
-      xit "returns an array with the step status information for each step in the program"
+      # todo: fix this spec so it is not dependant on running the whole suite
+      it "returns an array with the step status information for each step in the program" do
+        expect(test_run1.timeline).to eq(test_run1_timeline)
+      end
     end
 
     context "for a future program" do


### PR DESCRIPTION
This cleans up the unnecessary methods for running sightglass live and fixes a bug that would cause an exception if the step is still pending.